### PR TITLE
Testing "/boruto/heroes" endpoint - Part 2

### DIFF
--- a/src/main/kotlin/com/aarh/plugins/StatusPages.kt
+++ b/src/main/kotlin/com/aarh/plugins/StatusPages.kt
@@ -9,7 +9,7 @@ fun Application.configurationStatusPages() {
     install(StatusPages) {
         status(HttpStatusCode.NotFound) { call, status ->
             call.respond(
-                message = "404: Page not Found",
+                message = "404: Page not Found.",
                 status = status,
             )
         }

--- a/src/main/kotlin/com/aarh/routes/AllHeroes.kt
+++ b/src/main/kotlin/com/aarh/routes/AllHeroes.kt
@@ -27,7 +27,7 @@ fun Route.getAllHeroes() {
             call.respond(
                 message = ApiResponse(
                     success = false,
-                    message = "Only Numbers Allowed",
+                    message = "Only Numbers Allowed.",
                 ),
                 status = HttpStatusCode.BadRequest,
             )
@@ -35,7 +35,7 @@ fun Route.getAllHeroes() {
             call.respond(
                 message = ApiResponse(
                     success = false,
-                    message = "Heroes not Found",
+                    message = "Heroes not Found.",
                 ),
                 status = HttpStatusCode.NotFound,
             )

--- a/src/test/kotlin/com/aarh/ApplicationTest.kt
+++ b/src/test/kotlin/com/aarh/ApplicationTest.kt
@@ -65,50 +65,33 @@ class ApplicationTest {
     }
 
     @Test
-    fun `access all heroes endpoint, assert correct information`() = testApplication {
-        val heroRepository = HeroRepositoryImpl()
-        val response = client.get("/boruto/heroes")
+    fun `access all heroes endpoint, query non existing page number, assert error`() = testApplication {
+        val response = client.get("/boruto/heroes?page=6")
+        assertEquals(
+            expected = HttpStatusCode.NotFound,
+            actual = response.status,
+        )
+        assertEquals(
+            expected = "404: Page not Found.",
+            actual = response.bodyAsText(),
+        )
+    }
+
+    @Test
+    fun `access all heroes endpoint, query invalid page number, assert error`() = testApplication {
+        val response = client.get("/boruto/heroes?page=invalid")
         val expected = ApiResponse(
-            success = true,
-            message = "Ok",
-            prevPage = null,
-            nextPage = 2,
-            heroes = heroRepository.page1,
+            success = false,
+            message = "Only Numbers Allowed.",
         )
         val actual = Json.decodeFromString<ApiResponse>(response.bodyAsText())
-        println("EXPECTED: $expected")
-        println("ACTUAL: $actual")
-
         assertEquals(
-            expected = HttpStatusCode.OK,
+            expected = HttpStatusCode.BadRequest,
             actual = response.status,
         )
         assertEquals(
             expected = expected,
             actual = actual,
-        )
-    }
-
-    @Test
-    fun `access all heroes endpoint, query second page, assert correct information`() = testApplication {
-        val heroRepository = HeroRepositoryImpl()
-        val response = client.get("/boruto/heroes?page=2")
-        val expected = ApiResponse(
-            success = true,
-            message = "Ok",
-            prevPage = 1,
-            nextPage = 3,
-            heroes = heroRepository.page2,
-        )
-        val actual = Json.decodeFromString<ApiResponse>(response.bodyAsText())
-
-        assertEquals(
-            actual = HttpStatusCode.OK,
-            expected = response.status,
-        )
-        assertEquals(
-            actual = expected,
-            expected = actual,
         )
     }
 


### PR DESCRIPTION
Testing root endpoint - Part 2

Creation of error unit testing functions for endpoints "/boruto/heroes?page=6" and "/boruto/heroes?page=invalid" and resolved errors generated by the most current version of the unit test library

Changing text in invalid answers